### PR TITLE
validateAccepted: Accept checkboxes without explicit value

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -296,7 +296,7 @@ class Validator {
 	 */
 	protected function validateAccepted($attribute, $value)
 	{
-		return $this->validateRequired($attribute, $value) and ($value == 'yes' or $value == '1');
+		return $this->validateRequired($attribute, $value) and ($value == 'yes' or $value == 'on' or $value == '1');
 	}
 
 	/**


### PR DESCRIPTION
If you don't add a `value` attribute to a checkbox, at least Chrome sends `on` as a value for that field.

That should count as accepted, too, so I added this value.

I am not sure about the behaviour of other browsers, so I'd appreciate some resources if anybody has any.
I would even argue that we could simply check whether there was a value, or is the idea behind not allowing values like `no` make it easy to use this validator along with a two-option radio group ("Yes" and "no")?

Maybe we should just change this to use an array of allowed values and `inArray()`. I'll probably have to adapt the tests, too.
