### PR TITLE
Can inject dependencies into custom rule.

### DIFF
--- a/Validator.php
+++ b/Validator.php
@@ -536,10 +536,15 @@ class Validator implements ValidatorContract
         // attribute is invalid and we will add a failure message for this failing attribute.
         $validatable = $this->isValidatable($rule, $attribute, $value);
 
-        if ($rule instanceof RuleContract) {
+        if (is_subclass_of($rule, RuleContract::class)) {
+            if (is_string($rule)) {
+                $rule = $this->container->make($rule);
+            }
+
             return $validatable
-                    ? $this->validateUsingCustomRule($attribute, $value, $rule)
-                    : null;
+                ? $this->validateUsingCustomRule($attribute, $value, $rule)
+                : null;
+
         }
 
         $method = "validate{$rule}";


### PR DESCRIPTION
Hello folks,

I propose to inject dependencies into custom rule like that :

Declaration of the custom rule :

```php
<?php

namespace App\Rules;

use App\Services\Password;
use Illuminate\Contracts\Validation\Rule;

class PasswordStrength implements Rule
{
    /**
     * @var \App\Services\Auth\Password
     */
    protected $password;

    public function __construct(Password $password)
    {
        $this->password = $password;
    }

    /**
     * Determine if the validation rule passes.
     *
     * @param  string  $attribute
     * @param  mixed  $value
     * @return bool
     */
    public function passes($attribute, $value)
    {
        return $this->password->isStrong($value);
    }
}
```

After that, we can use our new custom rule into a controller or a form request like this :

```php
$request->validate([
    'password' => ['required', 'confirmed', \App\Rules\PasswordStrength::class],
]);

```

What do you think about that ?