### PR TITLE
Create validateNotArray function

### DIFF
--- a/Concerns/ValidatesAttributes.php
+++ b/Concerns/ValidatesAttributes.php
@@ -1937,4 +1937,19 @@ trait ValidatesAttributes
             $this->numericRules[] = $rule;
         }
     }
+    
+     /**
+     * Validate an attribute is not aray.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function validateNotArray($attribute, $value)
+    {
+        if(is_array($value) && $this->hasRule($attribute, 'Array')
+           {
+               return false;
+           }    
+            
+    }    
 }


### PR DESCRIPTION
Sometimes we need to prevent to arrays from input.For examles it creates weakness in hash usage.
Example:
$secret = 'secure_random_secret_value';
$hmac = md5($secret . $_POST['message']);
if($hmac == $_POST['hmac'])
        shell_exec($_POST['message']);

Code:
    var_dump("0e123" == "0e51217526859264863");
Output:
    bool(true)
This is also a problem in databases with lots of users. Using this format, an attacker can try to log into every single user account with a password that will result in a hash of the mentioned format. If there is a hash with the same format in the database, he will be logged in as the user that the hash belongs to, without needing to know the password.