### PR TITLE
Update FilterEmailValidation.php

### DIFF
--- a/Concerns/FilterEmailValidation.php
+++ b/Concerns/FilterEmailValidation.php
@@ -40,10 +40,9 @@ class FilterEmailValidation implements EmailValidation
      * Returns true if the given email is valid.
      *
      * @param  string  $email
-     * @param  \Egulias\EmailValidator\EmailLexer  $emailLexer
      * @return bool
      */
-    public function isValid(string $email, EmailLexer $emailLexer): bool
+    public function isValid(string $email): bool
     {
         return is_null($this->flags)
                     ? filter_var($email, FILTER_VALIDATE_EMAIL) !== false


### PR DESCRIPTION
Remove unused $emailLexer from isValid() as this only checks against native PHP filter_var.
It seems that there are other remnants of EmailLexer throughout the page, but I don't feel comfortable touching those.