### PR TITLE
Add 'ContainsSubstring' validation rule

### DIFF
--- a/Rules/ContainsSubstring.php
+++ b/Rules/ContainsSubstring.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class ContainsSubstring extends Rule
+{
+    /**
+     * @var 
+     */
+    protected $substring;
+
+    /**
+     * @param $substring
+     */
+    public function __construct($substring)
+    {
+        $this->substring = $substring;
+    }
+
+    /**
+     * @param $attribute
+     * @param $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        return str_contains($value, $this->substring);
+    }
+
+    /**
+     * @return string
+     */
+    public function message(): string
+    {
+        return "The :attribute must contain the substring '{$this->substring}'.";
+    }
+}


### PR DESCRIPTION
Add 'ContainsSubstring' validation rule

This commit introduces a new validation rule called 'ContainsSubstring' to the 'Validation\Rules' namespace. The rule allows developers to validate if a given string contains a specific substring.

The 'ContainsSubstring' rule can be used in Laravel's validation system to ensure that a field or input contains a required substring. It provides flexibility in validating input based on custom substring requirements.

Example usage:
```php
use Illuminate\Validation\Rule;
use App\Validation\Rules\ContainsSubstring;

$request->validate([    'title' => ['required', new ContainsSubstring('example')],
]);
